### PR TITLE
Fix: The tour page can now be viewed fully on a shorter screen.

### DIFF
--- a/src/sass/views/onboarding/onboard-welcome.scss
+++ b/src/sass/views/onboarding/onboard-welcome.scss
@@ -23,7 +23,7 @@
   #logo {
     width: 40%;
     max-width: 200px;
-    margin: auto 0;
+    margin: $bar-height 0 auto;
   }
   #lead {
     line-height: 1.6;

--- a/www/views/onboarding/tour.html
+++ b/www/views/onboarding/tour.html
@@ -1,8 +1,5 @@
 <ion-view id="onboard-welcome" class="onboarding">
-  <ion-nav-bar>
-    <ion-nav-title></ion-nav-title>
-  </ion-nav-bar>
-  <ion-content id="onboard-tour-control" scroll="false" ng-init="createProfile()">
+  <ion-content id="onboard-tour-control" ng-init="createProfile()">
     <img src='img/app/logo-negative.png' id="logo" />
     <div class="onboarding-topic" translate>You control your bitcoin.</div>
     <div class="onboarding-description" translate>This app stores your bitcoin locally on your device with cutting-edge security.</div>


### PR DESCRIPTION
Most important for phones like the Samsung Galaxy S6 and iPhone SE, but it's also better for the new iPhone 8 too.  Previously, the "Restore from backup" button was sometimes completely hidden or partially obscured.