### PR TITLE
Bug - 383 - Disappearing keyboard due to the keyboard

### DIFF
--- a/src/js/routes.js
+++ b/src/js/routes.js
@@ -1383,6 +1383,11 @@ angular.module('copayApp').config(function(historicLogProvider, $provide, $logPr
     }
 
     $rootScope.$on('$stateChangeStart', function(event, toState, toParams, fromState, fromParams) {
+      if (document.body.classList.contains('keyboard-open')) {
+        document.body.classList.remove('keyboard-open');
+        $log.debug('Prevented keyboard open bug..');
+      }
+
       $log.debug('Route change from:', fromState.name || '-', ' to:', toState.name);
       $log.debug('            toParams:' + JSON.stringify(toParams || {}));
       $log.debug('            fromParams:' + JSON.stringify(fromParams || {}));


### PR DESCRIPTION
Issue on iOS where the menu disappears when the keyboard is busy opening.

**Example**
This is an example where this happened (with "Slow Animations" option on in the iOS Simulator, to get a better view on what happens) 

![example - with slow animations](https://user-images.githubusercontent.com/5197265/41461253-808d7f06-708f-11e8-8257-a00cd646eda2.gif)

**To reproduce the issue on an old version**
Abort the screen while the keyboard is busy popping up.