### PR TITLE
Bug - 340 - Scan screen - Denying and then allowing camera permissions cause screen to block

### DIFF
--- a/src/js/controllers/tab-scan.js
+++ b/src/js/controllers/tab-scan.js
@@ -122,8 +122,12 @@ angular.module('copayApp.controllers').controller('tabScanController', function(
     scannerService.openSettings();
   };
 
+  $scope.reactivationCount = 0;
   $scope.attemptToReactivate = function(){
-    scannerService.reinitialize();
+    scannerService.reinitialize(function(){
+      $scope.reactivationCount++;
+      activate();
+    });
   };
 
   $scope.toggleLight = function(){

--- a/src/js/services/scannerService.js
+++ b/src/js/services/scannerService.js
@@ -103,6 +103,7 @@ angular.module('copayApp.services').service('scannerService', function($log, $ti
           _completeInitialization(status, callback);
         });
       } else {
+        isAvailable = true; // XX SP: Availability can change after permissions are granted after being denied.
         _completeInitialization(status, callback);
       }
     });

--- a/www/views/tab-scan.html
+++ b/www/views/tab-scan.html
@@ -16,7 +16,7 @@
       <div class="zero-state-description" translate>You can scan bitcoin addresses, payment requests, paper wallets, and more.</div>
       <div class="zero-state-cta">
         <div class="ng-hide zero-state-tldr" ng-show="!currentState || currentState === scannerStates.unauthorized" translate>Enable the camera to get started.</div>
-        <div class="ng-hide zero-state-tldr" ng-show="currentState === scannerStates.denied" translate>Enable camera access in your device settings to get started.</div>
+        <div class="ng-hide zero-state-tldr" ng-show="currentState === scannerStates.denied || reactivationCount > 2" translate>Enable camera access in your device settings to get started.</div>
         <div class="ng-hide zero-state-tldr" ng-show="currentState === scannerStates.unavailable" translate>Please connect a camera to get started.</div>
         <button ng-show="!currentState || currentState === scannerStates.unauthorized" class="ng-hide button button-standard button-primary" ng-click="authorize()" translate>Allow Camera Access</button>
         <button ng-show="currentState === scannerStates.denied && canOpenSettings" class="ng-hide button button-standard button-primary" ng-click="openSettings()" translate>Open Settings</button>


### PR DESCRIPTION
- Also forced the message to enter the device settings after 3 retries (applies to iOS only, as iOS never shows the permission message again after denying)