### PR TITLE
595 - Get Android build working again

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -71,7 +71,7 @@ module.exports = function(grunt) {
       sign_android: {
         // When the build log outputs "Built the following apk(s):", it seems to need the filename to start with "android-release".
         // It looks like it simply lists all apk files starting with "android-release"
-        command: 'rm -f platforms/android/build/outputs/apk/android-release-signed-*.apk; jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ../bitcoin-com-release-key.jks -signedjar platforms/android/build/outputs/apk/android-release-signed.apk  platforms/android/build/outputs/apk/android-release-unsigned.apk bitcoin-com && zipalign -v 4 platforms/android/build/outputs/apk/android-release-signed.apk platforms/android/build/outputs/apk/bitcoin-com-wallet-<%= pkg.fullVersion %>-android-signed-aligned.apk',
+        command: 'rm -f platforms/android/build/outputs/apk/release/*-android-signed-aligned.apk; jarsigner -verbose -sigalg SHA1withRSA -digestalg SHA1 -keystore ../bitcoin-com-release-key.jks -signedjar platforms/android/build/outputs/apk/release/android-release-signed.apk  platforms/android/build/outputs/apk/release/android-release-unsigned.apk bitcoin-com && zipalign -v 4 platforms/android/build/outputs/apk/release/android-release-signed.apk platforms/android/build/outputs/apk/release/bitcoin-com-wallet-<%= pkg.fullVersion %>-android-signed-aligned.apk',
         stdin: true,
       },
       sign_desktop_dist: {

--- a/app-template/config-template.xml
+++ b/app-template/config-template.xml
@@ -77,7 +77,7 @@
     </plugin>
     <!-- Supported Platforms -->
     <engine name="ios" spec="~4.5.3" />
-    <engine name="android" spec="~6.3.0" />
+    <engine name="android" spec="~6.4.0" />
     <engine name="windows" spec="~5.0.0" />
 
     <!-- Platform Specific Settings -->

--- a/src/android/build-extras.gradle
+++ b/src/android/build-extras.gradle
@@ -1,5 +1,6 @@
 ext {
   ANDROID_SUPPORT_V4_VERSION = '26.1.0'
+  ANDROID_SUPPORT_ANNOTATIONS_VERSION = '26.1.0'
 }
 
 configurations.all {


### PR DESCRIPTION
Android debug and release builds work when Gradle 3.3 is in PATH.