### PR TITLE
570 - Fee request to BWS uses wrong coin and network parameters.

### DIFF
--- a/src/js/services/feeService.js
+++ b/src/js/services/feeService.js
@@ -77,20 +77,20 @@ angular.module('copayApp.services').factory('feeService', function($log, $timeou
     var walletClient = bwcService.getClient(null, opts);
 
     walletClient.getFeeLevels(coin, 'livenet', function(errLivenet, levelsLivenet) {
-      walletClient.getFeeLevels('btc', 'testnet', function(errTestnet, levelsTestnet) {
-        if (errLivenet || errTestnet) {
-          return cb(gettextCatalog.getString('Could not get dynamic fee'));
-        }
+      if (errLivenet) {
+        return cb(gettextCatalog.getString('Could not get dynamic fee'));
+      }
 
-        cache.updateTs = Date.now();
-        cache.coin = coin;
-        cache.data = {
-          'livenet': levelsLivenet,
-          'testnet': levelsTestnet
-        };
+      cache.updateTs = Date.now();
+      cache.coin = coin;
+      cache.data = {
+        'livenet': levelsLivenet,
+        // Just in case there is some old code around that wants testnet data
+        'testnet': levelsLivenet 
+      };
 
-        return cb(null, cache.data);
-      });
+      return cb(null, cache.data);
+    
     });
   };
 


### PR DESCRIPTION
Part of the fix involved removing some testnet requests since we don't support it anymore. Are we sure we want to do that?