### PR TITLE
Update show identity check retry condition

### DIFF
--- a/src/js/controllers/buy-bitcoin/kyc-status.controller.js
+++ b/src/js/controllers/buy-bitcoin/kyc-status.controller.js
@@ -133,7 +133,7 @@ angular
           vm.statusTitle = gettextCatalog.getString('Verification Failed');
           vm.description = gettextCatalog.getString("We're sorry but we're not able to verify you at this time.");
           vm.graphicUri = "img/buy-bitcoin/failed.svg";
-          if(rejectType === 'retry') {
+          if(rejectType !== 'final') {
             vm.showRetry = true;
           }
           break;


### PR DESCRIPTION
Small change that will allow users with approved documents but rejected information (such as address and date of birth not matching with documents) to go through the KYC flow again.

Explanation: `rejectType` has now three possible values.

1. `final`: Final reject
2. `retry`: A reject that can be fixed by uploading a new image
3. `external`: Everything is fine with submitted documents but there are some external reasons to reject, such as address not matching or date of birth not matching

It’s allowed to update Customer object and upload files for the reasons 2. and 3. but you can improve the flow in the future, only asking the user for the rejected informations.