### PR TITLE
Add support for the standard BCH derivation path

### DIFF
--- a/src/js/services/derivationPathHelper.js
+++ b/src/js/services/derivationPathHelper.js
@@ -34,6 +34,7 @@ angular.module('copayApp.services').factory('derivationPathHelper', function(lod
 
     switch (arr[2]) {
       case "0'":
+      case "145'":
         ret.networkName = 'livenet';
         break;
       case "1'":


### PR DESCRIPTION
Don't fail when derivation path m/44'/145'/* is specified, as it's the standard Bitcoin Cash derivation 
path, as defined here https://github.com/satoshilabs/slips/blob/master/slip-0044.md